### PR TITLE
(#137) Add snapshot file for stack dependency resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,17 @@ Twitch/Discord Chat Bot that works for KGB ![monkaS](https://cdn.betterttv.net/e
 
 ## Quick Start
 
+### Cabal
+
 ```console
 $ cabal v2-build
 $ cabal v2-run kgbotka secret.json database.db
+```
+
+### Stack
+
+```console
+$ stack init --resolver=snapshot.yaml
+$ stack build
+$ stack run kgbotka secret.json database.db
 ```

--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -1,0 +1,13 @@
+resolver: lts-14.27
+compiler: ghc-8.6.5
+
+packages:
+  - discord-haskell-1.4.0
+  - hookup-0.3.1.0
+  - irc-core-2.7.2
+  - louis-0.1.0.2
+  - network-2.7.0.2
+  - regex-base-0.94.0.0
+  - regex-tdfa-1.3.1.0
+  - text-1.2.4.0
+  - emoji-0.1.0.2


### PR DESCRIPTION
Fixes #137

When building with stack the following can now be done:
```bash
$ stack init --resolver=snapshot.yaml
$ stack build
```
If you want me to update the Readme, I'll do that. Otherwise you can also do it right on the stream.