### PR TITLE
%calc function for Eval

### DIFF
--- a/kgbotka.cabal
+++ b/kgbotka.cabal
@@ -85,6 +85,7 @@ executable kgbotka
 
   -- Modules included in this executable, other than Main.
   other-modules:       KGBotka.Migration
+                     , KGBotka.Calc
                      , KGBotka.Command
                      , KGBotka.Parser
                      , KGBotka.Expr

--- a/src/KGBotka/Calc.hs
+++ b/src/KGBotka/Calc.hs
@@ -22,22 +22,6 @@ data Operator
   | Pow
   deriving (Show, Eq)
 
-charToOperator :: Char -> Operator
-charToOperator '+' = Add
-charToOperator '-' = Sub
-charToOperator '*' = Mul
-charToOperator '/' = Div
-charToOperator '%' = Mod
-charToOperator '^' = Pow
-charToOperator _ =
-    -- TODO: Make charToOperator not throw an exception
-    -- For now it is an unsafe function because it indicates
-    -- that operators were added but the parsers were not
-    -- corrected.
-  error
-    "charToOperator: No pattern for operator conversion. \
-    \Maybe you added a new operator and forgot to add a case to the conversion function."
-
 data CalcExpression
   = BinaryExpression Operator CalcExpression CalcExpression
   | NegativeExpression CalcExpression
@@ -77,7 +61,7 @@ parseAdditive = parseAdditive' <|> parseMultiplicative
   where
     parseAdditive' = do
       left <- parseMultiplicative
-      operator <- charToOperator <$> (charP '+' <|> charP '-')
+      operator <- (Add <$ charP '+') <|> (Sub <$ charP '-')
       BinaryExpression operator left <$> parseAdditive
 
 parseMultiplicative :: Parser CalcExpression
@@ -85,7 +69,8 @@ parseMultiplicative = parseMultiplicative' <|> parseExponentiation
   where
     parseMultiplicative' = do
       left <- parseExponentiation
-      operator <- charToOperator <$> (charP '*' <|> charP '/' <|> charP '%')
+      operator <-
+        (Mul <$ charP '*') <|> (Div <$ charP '/') <|> (Mod <$ charP '%')
       BinaryExpression operator left <$> parseMultiplicative
 
 parseExponentiation :: Parser CalcExpression
@@ -93,7 +78,7 @@ parseExponentiation = parseExponentiation' <|> parseAtom
   where
     parseExponentiation' = do
       left <- parseNegation
-      operator <- charToOperator <$> charP '^'
+      operator <- Pow <$ charP '^'
       BinaryExpression operator left <$> parseExponentiation
 
 parseNegation :: Parser CalcExpression

--- a/src/KGBotka/Calc.hs
+++ b/src/KGBotka/Calc.hs
@@ -83,7 +83,7 @@ parseExponentiation = parseExponentiation' <|> parseAtom
   where
     parseExponentiation' = do
       left <- parseNegation
-      operator <- charToOperator <$> (charP '^')
+      operator <- charToOperator <$> charP '^'
       BinaryExpression operator left <$> parseExponentiation
 
 parseNegation :: Parser CalcExpression
@@ -97,7 +97,7 @@ parseFunctionApplication :: Parser CalcExpression
 parseFunctionApplication = do
   functionName <- notNull "Expected a function name" $ takeWhileP isAlpha
   FunctionApplication functionName <$>
-    (inParens $ sepBy parseExpression (charP ',' <* ws) <|> return [])
+    inParens (sepBy parseExpression (charP ',' <* ws) <|> return [])
 
 parseValue :: Parser CalcExpression
 parseValue = ValueExpression <$> parseNumber

--- a/src/KGBotka/Calc.hs
+++ b/src/KGBotka/Calc.hs
@@ -51,14 +51,6 @@ newtype CalcEvalError =
 
 type CalcEval = ExceptT CalcEvalError IO
 
-hasChar :: Char -> Parser Bool
-hasChar c =
-  Parser $ \input ->
-    case T.uncons input of
-      Just (c', rest)
-        | c' == c -> Right (rest, True)
-      _ -> Right (input, False)
-
 parseNumber :: Parser Double
 parseNumber = parseFloating <|> parseInteger
   where

--- a/src/KGBotka/Calc.hs
+++ b/src/KGBotka/Calc.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE OverloadedStrings #-}
+module KGBotka.Calc where
+
+import KGBotka.Parser
+import Control.Applicative (Alternative(..))
+import Control.Monad (void)
+import Data.Char (isDigit, isAlpha)
+import qualified Data.Text as T
+
+data Operator
+  = Add
+  | Sub
+  | Mul
+  | Div
+  | Mod
+  | Pow
+  deriving (Show, Eq)
+
+charToOperator :: Char -> Operator
+charToOperator '+' = Add
+charToOperator '-' = Sub
+charToOperator '*' = Mul
+charToOperator '/' = Div
+charToOperator '%' = Mod
+charToOperator '^' = Pow
+charToOperator _ =
+  error
+    "charToOperator: No pattern for operator conversion. \
+    \Maybe you added a new operator and forgot to add a case to the conversion function."
+
+data CalcExpression
+  = BinaryExpression Operator CalcExpression CalcExpression
+  | NegativeExpression CalcExpression
+  | FunctionApplication T.Text [CalcExpression]
+  | ValueExpression Double
+  deriving (Show)
+
+hasChar :: Char -> Parser Bool
+hasChar c =
+  Parser $ \input ->
+    case T.uncons input of
+      Just (c', rest) | c' == c -> Right (rest, True)
+      _ -> Right (input, False)
+
+parseNumber :: Parser Double
+parseNumber = parseFloating <|> parseInteger
+  where
+    parseNumeric :: Parser T.Text
+    parseNumeric = notNull "Expected a numeric value" $ takeWhileP isDigit
+    parseInteger :: Parser Double
+    parseInteger = read . T.unpack <$> parseNumeric
+    parseFloating :: Parser Double
+    parseFloating = do
+      integerPart <- parseNumeric
+      void $ charP '.'
+      fractionalPart <- parseNumeric
+      return $ read $ T.unpack $ integerPart <> "." <> fractionalPart
+
+parseLine :: Parser CalcExpression
+parseLine = parseExpression <* eof
+
+parseExpression :: Parser CalcExpression
+parseExpression = parseAdditive
+
+parseAdditive :: Parser CalcExpression
+parseAdditive = parseAdditive' <|> parseMultiplicative
+  where
+    parseAdditive' = do
+      left <- parseMultiplicative
+      operator <- charToOperator <$> (charP '+' <|> charP '-')
+      BinaryExpression operator left <$> parseAdditive
+
+parseMultiplicative :: Parser CalcExpression
+parseMultiplicative = parseMultiplicative' <|> parseExponentiation
+  where
+    parseMultiplicative' = do
+      left <- parseExponentiation
+      operator <- charToOperator <$> (charP '*' <|> charP '/' <|> charP '%')
+      BinaryExpression operator left <$> parseMultiplicative
+
+parseExponentiation :: Parser CalcExpression
+parseExponentiation = parseExponentiation' <|> parseAtom
+  where
+    parseExponentiation' = do
+      left <- parseNegation
+      operator <- charToOperator <$> (charP '^')
+      BinaryExpression operator left <$> parseExponentiation
+
+parseNegation :: Parser CalcExpression
+parseNegation = parseNegation' <|> parseAtom
+  where
+    parseNegation' = do
+      void $ charP '-'
+      NegativeExpression <$> parseNegation
+
+parseFunctionApplication :: Parser CalcExpression
+parseFunctionApplication = do
+  functionName <- notNull "Expected a function name" $ takeWhileP isAlpha
+  FunctionApplication functionName <$>
+    (inParens $ sepBy parseExpression (charP ',' <* ws) <|> return [])
+
+parseValue :: Parser CalcExpression
+parseValue = ValueExpression <$> parseNumber
+
+parseAtom :: Parser CalcExpression
+parseAtom =
+  ws *> (parseValue <|> parseFunctionApplication <|> inParens parseExpression) <*
+  ws

--- a/src/KGBotka/Calc.hs
+++ b/src/KGBotka/Calc.hs
@@ -30,6 +30,10 @@ charToOperator '/' = Div
 charToOperator '%' = Mod
 charToOperator '^' = Pow
 charToOperator _ =
+    -- TODO: Make charToOperator not throw an exception
+    -- For now it is an unsafe function because it indicates
+    -- that operators were added but the parsers were not
+    -- corrected.
   error
     "charToOperator: No pattern for operator conversion. \
     \Maybe you added a new operator and forgot to add a case to the conversion function."
@@ -62,6 +66,7 @@ parseNumber = parseFloating <|> parseInteger
     parseNumeric = notNull "Expected a numeric value" $ takeWhileP isDigit
     parseInteger :: Parser Double
     parseInteger = read . T.unpack <$> parseNumeric
+    -- TODO: parseFloating does not support exponential number format
     parseFloating :: Parser Double
     parseFloating = do
       integerPart <- parseNumeric
@@ -112,6 +117,7 @@ parseFunctionApplication = do
   FunctionApplication functionName <$>
     inParens (sepBy parseExpression (charP ',' <* ws) <|> return [])
 
+-- TODO: Make calc variables a seperate constructor of CalcExpression
 parseVariable :: Parser CalcExpression
 parseVariable = do
   varName <- notNull "Expected a variable name" $ takeWhileP isAlpha

--- a/src/KGBotka/Eval.hs
+++ b/src/KGBotka/Eval.hs
@@ -387,6 +387,8 @@ evalExpr (FunCallExpr "calc" args) = do
     parserStopToEvalError EOF = EvalError "Calc: Unexpected EOF"
     parserStopToEvalError (SyntaxError msg) =
       EvalError $ "Syntax error: " <> msg
+    -- TODO: There might be a better way to do the job of calcResultToEval
+    -- instead of unwrapping the ExceptT
     calcResultToEval :: Either CalcEvalError Double -> Eval T.Text
     calcResultToEval calcResult =
       case calcResult of

--- a/src/KGBotka/Eval.hs
+++ b/src/KGBotka/Eval.hs
@@ -475,6 +475,22 @@ functionLookupTable =
       , \case
           [x] -> return $ tan x
           _ -> throwExceptEval $ EvalError "tan expects one argument")
+    , ( "arcsin"
+      , \case
+          [x] -> return $ asin x
+          _ -> throwExceptEval $ EvalError "arcsin expects one argument")
+    , ( "arccos"
+      , \case
+          [x] -> return $ acos x
+          _ -> throwExceptEval $ EvalError "arccos expects one argument")
+    , ( "arctan"
+      , \case
+          [x] -> return $ atan x
+          _ -> throwExceptEval $ EvalError "arctan expects one argument")
+    , ( "exp"
+      , \case
+          [x] -> return $ exp x
+          _ -> throwExceptEval $ EvalError "exp expects one argument")
     , ( "nthroot"
       , \case
           [n, x] -> return $ n ** recip x

--- a/src/KGBotka/Eval.hs
+++ b/src/KGBotka/Eval.hs
@@ -458,7 +458,7 @@ evalCalcExpression (ValueExpression val) = return val
 evalCalcExpression (FunctionApplication functionName args) =
     case M.lookup functionName functionLookupTable of
       Just f -> mapM evalCalcExpression args >>= f
-      Nothing -> throwExceptEval $ EvalError $ "undefined is not a function FeelsDankMan"
+      Nothing -> throwExceptEval $ EvalError "undefined is not a function FeelsDankMan"
 
 functionLookupTable :: M.Map T.Text ([Double] -> Eval Double)
 functionLookupTable =
@@ -497,7 +497,7 @@ functionLookupTable =
           _ -> throwExceptEval $ EvalError "nthroot expects two arguments (radix and radicand)")
     , ( "sqrt"
       , \case
-          [x] -> return $ x ** 0.5
+          [x] -> return $ sqrt x
           _ -> throwExceptEval $ EvalError "sqrt expects one argument")
     , ( "random"
       , \case

--- a/src/KGBotka/Eval.hs
+++ b/src/KGBotka/Eval.hs
@@ -378,11 +378,11 @@ evalExpr (FunCallExpr "calc" args) = do
   (rest, parsedExpression) <-
     exceptEval $
     first parserStopToEvalError $ runParser parseLine mathsExpression
-  case T.unpack rest of
-    [] -> do
+  if T.null rest
+    then do
       calcResult <- lift $ runExceptT $ evalCalcExpression parsedExpression
       calcResultToEval calcResult
-    _ -> throwExceptEval $ EvalError "Calc: Incomplete parse PepeHands"
+    else throwExceptEval $ EvalError "Calc: Incomplete parse PepeHands"
   where
     parserStopToEvalError EOF = EvalError "Calc: Unexpected EOF"
     parserStopToEvalError (SyntaxError msg) =

--- a/src/KGBotka/Parser.hs
+++ b/src/KGBotka/Parser.hs
@@ -40,9 +40,7 @@ instance Alternative Parser where
         (x, _) -> x
 
 ws :: Parser ()
-ws = do
-  void $ takeWhileP $ flip elem (" \t\n\r" :: [Char])
-  return ()
+ws = void $ takeWhileP $ flip elem (" \t\n\r" :: String)
 
 sepBy :: Parser a -> Parser b -> Parser [a]
 sepBy element sep = do

--- a/src/KGBotka/Parser.hs
+++ b/src/KGBotka/Parser.hs
@@ -4,6 +4,7 @@
 module KGBotka.Parser where
 
 import Control.Applicative
+import Control.Monad
 import qualified Data.Text as T
 import Data.Tuple
 
@@ -38,6 +39,11 @@ instance Alternative Parser where
         (Left _, x) -> x
         (x, _) -> x
 
+ws :: Parser ()
+ws = do
+  void $ takeWhileP $ flip elem (" \t\n\r" :: [Char])
+  return ()
+
 sepBy :: Parser a -> Parser b -> Parser [a]
 sepBy element sep = do
   arg <- element
@@ -63,5 +69,14 @@ notNull message next =
        then syntaxError message
        else return value)
 
+inParens :: Parser a -> Parser a
+inParens p = charP '(' *> p <* charP ')'
+
 syntaxError :: T.Text -> Parser a
 syntaxError message = Parser $ \_ -> Left $ SyntaxError message
+
+eof :: Parser ()
+eof = Parser $ \input ->
+      case T.unpack input of
+        [] -> Right (mempty, ())
+        _ -> Left $ SyntaxError "Expected EOF"


### PR DESCRIPTION
Adds a `%calc()` function to the KGBotka.Eval module.

I left off some TODOs for unfinished work / things that can be improved.
The implementation of the %calc evaluation mechanism is independent from the eval mechanism of the Eval module, because otherwise it would introduce cyclic dependencies of the modules. 
Another advantage is, that the encapsulating Eval module can be replaced completely. Just the function that converts an Either T.Text Double to a representing result type has to be adapted. (see `calcResultToEval`)

Please let me know if you see any issues that I can address.