### PR TITLE
Accommodate for changes #230 and #228 in the stack build system

### DIFF
--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -2,7 +2,7 @@ resolver: lts-14.27
 compiler: ghc-8.6.5
 
 packages:
-  - discord-haskell-1.4.0
+  - discord-haskell-1.6.0
   - hookup-0.3.1.0
   - irc-core-2.7.2
   - louis-0.1.0.2

--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -11,3 +11,4 @@ packages:
   - regex-tdfa-1.3.1.0
   - text-1.2.4.0
   - emoji-0.1.0.2
+  - base64-0.4.1


### PR DESCRIPTION
Stack automatically detects the discord-haskell package in the source tree. 
The only thing that had to be changed was the specified version in `snapshot.yaml`. 
Details in the commit message of 225e3b1 .
Also I added the base64-package to that file.

Tested on `Wed 24 Jun 2020 02:16:48 AM UTC` at commit 225e3b1 .