### PR TITLE
Fix Stack build with direct-sqlite

### DIFF
--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -12,3 +12,4 @@ packages:
   - text-1.2.4.0
   - emoji-0.1.0.2
   - base64-0.4.1
+  - direct-sqlite-2.3.26


### PR DESCRIPTION
The reference to the correct in-tree dependency was missing in the
snapshot.yaml file.
A checkout of the submodules is still required