### PR TITLE
Fix FreeBSD TLS certificate bug

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "third_party/direct-sqlite"]
 	path = third_party/direct-sqlite
 	url = https://github.com/tsoding/direct-sqlite
+[submodule "third_party/HsOpenSSL-x509-system"]
+	path = third_party/HsOpenSSL-x509-system
+	url = https://github.com/herrhotzenplotz/HsOpenSSL-x509-system

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,4 @@
 packages: ./
           ./third_party/discord-haskell/
           ./third_party/direct-sqlite/
+          ./third_party/HsOpenSSL-x509-system/


### PR DESCRIPTION
As discussed elsewhere, on FreeBSD I hit on an issue regarding the TLS certificate storage. For now, this adds a submodule that contains the fix (I already merged it into the master to make it build without requiring a manual checkout of the correct branch). 
This submodule can be removed once https://github.com/redneb/HsOpenSSL-x509-system/pull/2 is merged.

I hope this is an acceptable workaround for now.