### PR TITLE
Twitch-channel specific call-prefix

### DIFF
--- a/src/KGBotka/JoinedTwitchChannels.hs
+++ b/src/KGBotka/JoinedTwitchChannels.hs
@@ -47,11 +47,10 @@ callPrefixOfJoinedChannel dbConn channel =
 
 setPrefixOfJoinedChannel :: Sqlite.Connection -> TwitchIrcChannel -> T.Text -> IO ()
 setPrefixOfJoinedChannel dbConn channel prefix = do
-  Sqlite.executeNamed dbConn
-            [sql|UPDATE JoinedTwitchChannels SET channelCommandPrefix = :pref WHERE name = :channel;|]
-            [ ":channel" := channel
-            , ":pref" := prefix
-            ]
+  Sqlite.executeNamed
+    dbConn
+    [sql|UPDATE JoinedTwitchChannels SET channelCommandPrefix = :pref WHERE name = :channel;|]
+    [":channel" := channel, ":pref" := prefix]
 
 unregisterJoinedChannel :: Sqlite.Connection -> TwitchIrcChannel -> IO ()
 unregisterJoinedChannel dbConn channel =

--- a/src/KGBotka/JoinedTwitchChannels.hs
+++ b/src/KGBotka/JoinedTwitchChannels.hs
@@ -5,26 +5,53 @@ module KGBotka.JoinedTwitchChannels
   ( joinedChannels
   , registerJoinedChannel
   , unregisterJoinedChannel
+  , callPrefixOfJoinedChannel
+  , setPrefixOfJoinedChannel
   ) where
 
+import qualified Data.Text as T
 import qualified Database.SQLite.Simple as Sqlite
+import Database.SQLite.Simple.FromRow
 import Database.SQLite.Simple (NamedParam(..))
 import Database.SQLite.Simple.QQ
 import KGBotka.TwitchAPI
+
+data JoinedTwitchChannel = JoinedTwitchChannel
+    { joinedChannelTwitchChannel :: TwitchIrcChannel
+    , joinedChannelCallPrefix :: T.Text
+    }
+
+instance FromRow JoinedTwitchChannel where
+    fromRow = JoinedTwitchChannel <$> field <*> field
 
 joinedChannels :: Sqlite.Connection -> IO [TwitchIrcChannel]
 joinedChannels dbConn = do
   channels <-
     Sqlite.queryNamed dbConn [sql|SELECT * FROM JoinedTwitchChannels;|] []
-  return $ map Sqlite.fromOnly channels
+  return $ map joinedChannelTwitchChannel channels
 
 registerJoinedChannel :: Sqlite.Connection -> TwitchIrcChannel -> IO ()
 registerJoinedChannel dbConn channel =
   Sqlite.executeNamed
     dbConn
     [sql|INSERT INTO JoinedTwitchChannels (name)
-         VALUES (:channel)|]
+         VALUES (:channel);|]
     [":channel" := channel]
+
+callPrefixOfJoinedChannel :: Sqlite.Connection -> TwitchIrcChannel -> IO T.Text
+callPrefixOfJoinedChannel dbConn channel =
+    joinedChannelCallPrefix . head <$>
+                            Sqlite.queryNamed dbConn
+                                      [sql|SELECT * FROM JoinedTwitchChannels WHERE name = :channel;|]
+                                      [":channel" := channel]
+
+setPrefixOfJoinedChannel :: Sqlite.Connection -> TwitchIrcChannel -> T.Text -> IO ()
+setPrefixOfJoinedChannel dbConn channel prefix = do
+  Sqlite.executeNamed dbConn
+            [sql|UPDATE JoinedTwitchChannels SET channelCommandPrefix = :pref WHERE name = :channel;|]
+            [ ":channel" := channel
+            , ":pref" := prefix
+            ]
 
 unregisterJoinedChannel :: Sqlite.Connection -> TwitchIrcChannel -> IO ()
 unregisterJoinedChannel dbConn channel =

--- a/src/KGBotka/Migration.hs
+++ b/src/KGBotka/Migration.hs
@@ -233,4 +233,6 @@ kgbotkaMigrations =
              freq INTEGER,
              num INTEGER
            );|]
+  , Migration
+    [sql|ALTER TABLE JoinedTwitchChannels ADD COLUMN channelCommandPrefix TEXT NOT NULL DEFAULT '!';|]
   ]

--- a/src/KGBotka/Repl.hs
+++ b/src/KGBotka/Repl.hs
@@ -247,8 +247,7 @@ replThreadLoop rts = do
       withTransactionLogErrors $ \dbConn ->
         case chan of
           Nothing ->
-            replPutStrLn replHandle $
-            "setprefix only works in a joined channel."
+            replPutStrLn replHandle "setprefix only works in a joined channel."
           Just channel -> do
             setPrefixOfJoinedChannel dbConn channel prefix
             replPutStrLn replHandle $

--- a/src/KGBotka/Repl.hs
+++ b/src/KGBotka/Repl.hs
@@ -243,6 +243,14 @@ replThreadLoop rts = do
         Nothing ->
           replPutStrLn replHandle "There is no Markov retraining in place."
       replThreadLoop rts
+    ("setprefix":prefix:_, chan) -> do
+        withTransactionLogErrors $ \dbConn ->
+            case chan of
+              Nothing -> replPutStrLn replHandle $ "setprefix only works in a joined channel."
+              Just channel -> do
+                        setPrefixOfJoinedChannel dbConn channel prefix
+                        replPutStrLn replHandle $ "Updated call prefix for channel " <> twitchIrcChannelText channel
+        replThreadLoop rts
     (unknown:_, _) -> do
       replPutStrLn replHandle $ "Unknown command: " <> unknown
       replThreadLoop rts

--- a/src/KGBotka/Repl.hs
+++ b/src/KGBotka/Repl.hs
@@ -244,13 +244,16 @@ replThreadLoop rts = do
           replPutStrLn replHandle "There is no Markov retraining in place."
       replThreadLoop rts
     ("setprefix":prefix:_, chan) -> do
-        withTransactionLogErrors $ \dbConn ->
-            case chan of
-              Nothing -> replPutStrLn replHandle $ "setprefix only works in a joined channel."
-              Just channel -> do
-                        setPrefixOfJoinedChannel dbConn channel prefix
-                        replPutStrLn replHandle $ "Updated call prefix for channel " <> twitchIrcChannelText channel
-        replThreadLoop rts
+      withTransactionLogErrors $ \dbConn ->
+        case chan of
+          Nothing ->
+            replPutStrLn replHandle $
+            "setprefix only works in a joined channel."
+          Just channel -> do
+            setPrefixOfJoinedChannel dbConn channel prefix
+            replPutStrLn replHandle $
+              "Updated call prefix for channel " <> twitchIrcChannelText channel
+      replThreadLoop rts
     (unknown:_, _) -> do
       replPutStrLn replHandle $ "Unknown command: " <> unknown
       replThreadLoop rts

--- a/src/KGBotka/TwitchThread.hs
+++ b/src/KGBotka/TwitchThread.hs
@@ -36,7 +36,6 @@ import KGBotka.Markov
 import KGBotka.Queue
 import KGBotka.Repl
 import KGBotka.Roles
-import KGBotka.Settings
 import KGBotka.Sqlite
 import KGBotka.TwitchAPI
 import KGBotka.TwitchLog
@@ -275,9 +274,9 @@ processUserMsgs dbConn tts messages = do
                 let forbiddenCharLimit = 100
                 if countForbidden message < forbiddenCharLimit
                   then do
-                    settings <- fetchSettings dbConn
+                    prefix <- callPrefixOfJoinedChannel dbConn channel
                     case parseCommandPipe
-                           (settingsCallPrefix settings)
+                           (CallPrefix prefix)
                            (PipeSuffix "|")
                            message of
                       [] ->


### PR DESCRIPTION
I needed to change the call-prefix of commands per Twitch-channel. You can now change the prefix for a twitch channel in the repl by running e.g. `#tsoding> setprefix $` to set the command call prefix to `$`.
Prefix is stored in the `JoinedTwitchChannels` table. Default is `!`. Discord is not affected by this, it will still use the `Settings` table.

Please let me know if you have issues with that.