### PR TITLE
(#255) Remove obsolete git submodule for HsOpenSSL-x509-system

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "third_party/direct-sqlite"]
 	path = third_party/direct-sqlite
 	url = https://github.com/tsoding/direct-sqlite
-[submodule "third_party/HsOpenSSL-x509-system"]
-	path = third_party/HsOpenSSL-x509-system
-	url = https://github.com/herrhotzenplotz/HsOpenSSL-x509-system

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,3 @@
 packages: ./
           ./third_party/discord-haskell/
           ./third_party/direct-sqlite/
-          ./third_party/HsOpenSSL-x509-system/

--- a/kgbotka.cabal
+++ b/kgbotka.cabal
@@ -150,6 +150,7 @@ executable kgbotka
                      , discord-haskell >= 1.6.0 && < 1.7.0
                      , base64 >= 0.4 && < 0.5
                      , direct-sqlite ==2.3.26
+                     , HsOpenSSL-x509-system == 0.1.0.4
 
   -- Directories containing source files.
   hs-source-dirs:      src

--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -13,3 +13,4 @@ packages:
   - emoji-0.1.0.2
   - base64-0.4.1
   - direct-sqlite-2.3.26
+  - HsOpenSSL-x509-system-0.1.0.4


### PR DESCRIPTION
The submodule is now redundant since
https://github.com/redneb/HsOpenSSL-x509-system/pull/2 has been
resolved and pushed into the hackage.

This commit removes the submodule and forces the new dependency of
HsOpenSSL-x509-system-0.1.0.4 both on cabal and stack.

Fixes #255